### PR TITLE
aggiornati pacchetti critici segnalati da dependabot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cffi==1.17.1
 charset-normalizer==3.4.1
 click==8.1.8
 cryptography==45.0.3
-dnspython==1.16.0
+dnspython>=2.6.1
 fastapi==0.115.8
 filetype==1.2.0
 google-ai-generativelanguage==0.6.15
@@ -20,8 +20,8 @@ google-generativeai==0.8.4
 googleapis-common-protos==1.67.0
 grpcio==1.70.0
 grpcio-status==1.70.0
-h11==0.14.0
-httpcore==1.0.7
+h11>=0.16.0
+httpcore>=1.0.7
 httplib2==0.22.0
 httpx==0.28.1
 idna==3.10
@@ -34,7 +34,7 @@ langsmith==0.3.8
 orjson==3.10.15
 packaging==24.2
 proto-plus==1.26.0
-protobuf==5.29.3
+protobuf>=5.29.5
 pyasn1==0.6.1
 pyasn1_modules==0.4.1
 pycparser==2.22
@@ -42,12 +42,12 @@ pydantic==2.10.6
 pydantic-settings==2.9.1
 pydantic_core==2.27.2
 PyJWT==2.10.1
-pymongo==3.12.0
+pymongo>=4.6.3
 pyparsing==3.2.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
 PyYAML==6.0.2
-requests==2.32.3
+requests>=2.32.4
 requests-toolbelt==1.0.0
 rsa==4.9
 s3transfer==0.11.2


### PR DESCRIPTION
pymongo>=4.6.3
dnspython>=2.6.1
h11>=0.16.0
requests>=2.32.4
protobuf>=5.29.5

+ dependency h11>=0.16.0