### PR TITLE
Enable Swagger in production at /api/docs

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -15,10 +15,11 @@ from src.auth import VerifyToken
 auth = VerifyToken()
 
 app = FastAPI(
-    title='AIR Coach API', 
-    version='0.3', 
+    title='AIR Coach API',
+    version='0.3',
     description='API for AIR Coach agent<br />- with Gemini 2.5<br />- with tools',
-    #docs_url=None if is_production else "/api/docs",  # Disabilita /docs in produzione
+    docs_url="/api/docs",  # Swagger enabled in production
+    redoc_url="/api/redoc"  # ReDoc enabled in production
     )
 
 api_router = APIRouter(prefix="/api")


### PR DESCRIPTION
- Set explicit docs_url="/api/docs" for Swagger UI
- Added redoc_url="/api/redoc" for ReDoc documentation
- Removed conditional that disabled docs in production