### PR TITLE
fix: missing \n does not generate event stream

### DIFF
--- a/src/agent/streaming_handler.py
+++ b/src/agent/streaming_handler.py
@@ -60,7 +60,7 @@ class StreamingHandler:
                     
         except Exception as e:
             logger.error(f"Errore nello streaming con controllo tool: {e}")
-            yield f"data: {{'error': 'Errore nello streaming: {str(e)}'}}"
+            yield f"data: {{'error': 'Errore nello streaming: {str(e)}'}}\n\n"
     
     def _reset_state(self):
         """Reset dello stato interno per nuovo streaming."""
@@ -111,7 +111,7 @@ class StreamingHandler:
                 "data": self.serialized_output,
                 "final": True
             }
-            yield f"data: {json.dumps(structured_response)}"
+            yield f"data: {json.dumps(structured_response)}\n\n"
             logger.info(f"TOOL - {tool_name} output processed")
     
     async def _handle_model_stream(self, event: Dict) -> AsyncGenerator[str, None]:
@@ -125,7 +125,7 @@ class StreamingHandler:
                     "type": "agent_message",
                     "data": content_text
                 }
-                yield f"data: {json.dumps(ai_response)}"
+                yield f"data: {json.dumps(ai_response)}\n\n"
     
     def get_final_response(self) -> str:
         """Restituisce la risposta finale concatenata."""


### PR DESCRIPTION
Questa PR fa si che il protocollo  Server-Sent Events torni a funzionare come dovrebbe.
Immagino @maxvaega che va adeguato il test