### PR TITLE
fix(deps): bump langchain-core 1.2.12 → 1.3.3 (CVE-2026-44843) — fix #99

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ jmespath==1.0.1
 jsonpatch==1.33
 jsonpointer==3.0.0
 langchain==1.2.10
-langchain-core==1.2.12
+langchain-core==1.3.3
 langchain-google-genai==4.2.0
 langgraph==1.0.8
 langgraph-checkpoint==2.1.2
@@ -60,7 +60,7 @@ starlette==0.46.0
 tenacity==9.0.0
 tqdm==4.67.1
 typing-inspection==0.4.1
-typing_extensions==4.12.2
+typing_extensions==4.15.0
 uritemplate==4.1.1
 urllib3==2.3.0
 uuid_utils==0.14.0


### PR DESCRIPTION
## Summary

- Closes #99 by mitigating **CVE-2026-44843** ([GHSA-pjwx-r37v-7724](https://github.com/advisories/GHSA-pjwx-r37v-7724), CVSS 8.2 High) — unsafe deserialization in `langchain-core` via overly broad `load()` allowlists.
- Bumps `langchain-core` **1.2.12 → 1.3.3** (latest stable on the 1.3.x patch line).
- Bumps `typing_extensions` **4.12.2 → 4.15.0** (transitively required: `langchain-core 1.3.x` pulls in `langchain-protocol`, which uses `TypedDict(extra_items=…)` PEP 728 — runtime requires `typing_extensions>=4.13`).

## Why this is a low-risk bump

The project **does not invoke the vulnerable surface directly**:

- No imports/calls to `load()` / `loads()` / `dumpd()` / `dumps()` from `langchain_core.load`.
- No use of deprecated `RunnableWithMessageHistory` or `astream_log()`.
- The single `astream_events` call in `src/agent/streaming_handler.py:45` already uses `version="v2"` (not the deprecated `v1`).

This is therefore a defense-in-depth dependency upgrade to clear scanner findings and stay on the patched line.

## Compatibility (verified on PyPI)

All other deps accept `langchain-core 1.3.3` (constraint `<2.0.0`):

| Package | Constraint on `langchain-core` |
|---|---|
| `langchain==1.2.10` | `<2.0.0,>=1.2.10` |
| `langgraph==1.0.8` | `>=0.1` |
| `langgraph-checkpoint==2.1.2` | `>=0.2.38` |
| `langgraph-prebuilt==1.0.7` | `>=1.0.0` |
| `langchain-google-genai==4.2.0` | `<2.0.0,>=1.2.5` |

`pip check` reports no broken requirements.

## Test plan

- [x] `pytest -m unit -v` → **62 passed**
- [x] `pytest -m integration -v` → **29 passed**
- [ ] `pytest -m e2e -v` (manual server, optional pre-deploy validation)

Note: a `LangChainPendingDeprecationWarning` about `allowed_objects` defaults shows up from `langgraph.checkpoint`. It's a forward-looking notice from upstream (future tightening of the same allowlist this CVE addresses) — non-blocking, no action required from this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)